### PR TITLE
Remove Mapbox access token

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ import night from './os_open_zoomstack_-_night.json'
 
 // access Token
 mapboxgl.accessToken =
-  "pk.eyJ1IjoidHR2aWUiLCJhIjoiY2pzeWtpbnlmMTQ2bDQ0cHBmMG83cDc2cCJ9.PbFiXjCzENBncs0mErVLHQ";
+  "";
 
 // settings for layer and overlays
 var settings = {};


### PR DESCRIPTION
Hi @joe-liad happy to see QuattroMap is used elsewhere :-)

Currently your fork uses our Mapbox access token. As stated in the Readme (https://github.com/kreis-viersen/quattromap#search):

> For your own QuattroMap please use your own access token: https://docs.mapbox.com/help/how-mapbox-works/access-tokens/.

Thanks!